### PR TITLE
Add build caching to CICD

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -46,7 +46,7 @@ jobs:
           LINK: https://github.com/mozilla/sccache/releases/download
           SCCACHE_VERSION: 0.3.3
         run: |
-          SCCACHE_FILE=sccache-v$SCCACHE_VERSION-${{ matrix.target }}
+          SCCACHE_FILE=sccache-v$SCCACHE_VERSION-x86_64-unknown-linux-musl
           mkdir -p $HOME/.local/bin
           curl -L "$LINK/v$SCCACHE_VERSION/$SCCACHE_FILE.tar.gz" | tar xz
           mv -f $SCCACHE_FILE/sccache $HOME/.local/bin/sccache

--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -44,11 +44,11 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         env:
           LINK: https://github.com/mozilla/sccache/releases/download
-          SCCACHE_VERSION: 0.2.13
+          SCCACHE_VERSION: 0.3.3
         run: |
-          SCCACHE_FILE=sccache-$SCCACHE_VERSION-${{ matrix.target }}
+          SCCACHE_FILE=sccache-v$SCCACHE_VERSION-${{ matrix.target }}
           mkdir -p $HOME/.local/bin
-          curl -L "$LINK/$SCCACHE_VERSION/$SCCACHE_FILE.tar.gz" | tar xz
+          curl -L "$LINK/v$SCCACHE_VERSION/$SCCACHE_FILE.tar.gz" | tar xz
           mv -f $SCCACHE_FILE/sccache $HOME/.local/bin/sccache
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -14,6 +14,11 @@ jobs:
   binary-builds:
     name: Builds for ${{ matrix.target }} ${{ matrix.channel }} on ${{ matrix.os }}
     runs-on: ubuntu-latest
+    env:
+      SCCACHE_CACHE_SIZE: 2G
+      SCCACHE_DIR: ${{ matrix.sccache-path }}
+      RUSTC_WRAPPER: sccache
+      RUSTV: ${{ matrix.rust }}
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -27,23 +32,78 @@ jobs:
           # Linux arm64 gnu and musl
           - aarch64-unknown-linux-gnu
           - aarch64-unknown-linux-musl
+        include:
+          - os: ubuntu-latest
+            sccache-path: /home/runner/.cache/sccache
     steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - name: Install Rust ${{ matrix.target }} ${{ matrix.channel }}
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: ${{ matrix.channel }}
-        target: ${{ matrix.target }}
-        override: true
-    - name: ${{ matrix.target }} build
-      run: cargo build --release
-    - name: Upload binary artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: Niumside-Pop-Tracker_${{ matrix.channel }}-${{ matrix.target }}
-        path: target/release/niumside-poptracker
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: Install sccache (ubuntu-latest)
+        if: matrix.os == 'ubuntu-latest'
+        env:
+          LINK: https://github.com/mozilla/sccache/releases/download
+          SCCACHE_VERSION: 0.2.13
+        run: |
+          SCCACHE_FILE=sccache-$SCCACHE_VERSION-${{ matrix.target }}
+          mkdir -p $HOME/.local/bin
+          curl -L "$LINK/$SCCACHE_VERSION/$SCCACHE_FILE.tar.gz" | tar xz
+          mv -f $SCCACHE_FILE/sccache $HOME/.local/bin/sccache
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Install Rust ${{ matrix.target }} ${{ matrix.channel }}
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.channel }}
+          target: ${{ matrix.target }}
+          override: true
+
+      - name: Cache cargo registry
+        uses: actions/cache@v2
+        continue-on-error: false
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
+      - name: Save sccache
+        uses: actions/cache@v2
+        continue-on-error: false
+        with:
+          path: ${{ matrix.sccache-path }}
+          key: ${{ runner.os }}-sccache-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-sccache-
+
+      - name: Save sccache
+        uses: actions/cache@v2
+        continue-on-error: false
+        with:
+          path: ${{ matrix.sccache-path }}
+          key: ${{ runner.os }}-sccache-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-sccache-
+
+      - name: Start sccache server
+        run: sccache --start-server
+
+      - name: ${{ matrix.target }} build
+        run: cargo build --release
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: Niumside-Pop-Tracker_${{ matrix.channel }}-${{ matrix.target }}
+          path: target/release/niumside-poptracker
+
+      - name: Print sccache stats
+        run: sccache --show-stats
+      - name: Stop sccache server
+        run: sccache --stop-server || true
 
   docker-image-build:
     needs: binary-builds

--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -66,18 +66,18 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-
+            ${{ matrix.target }}-cargo-
 
       - name: Save sccache
         uses: actions/cache@v2
         continue-on-error: false
         with:
           path: ${{ matrix.sccache-path }}
-          key: ${{ runner.os }}-sccache-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ matrix.target }}-sccache-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-sccache-
+            ${{ matrix.target }}-sccache-
 
       - name: Start sccache server
         run: sccache --start-server

--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -79,15 +79,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-sccache-
 
-      - name: Save sccache
-        uses: actions/cache@v2
-        continue-on-error: false
-        with:
-          path: ${{ matrix.sccache-path }}
-          key: ${{ runner.os }}-sccache-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-sccache-
-
       - name: Start sccache server
         run: sccache --start-server
 


### PR DESCRIPTION
This PR will add build caching to the CICD. The first iteration will focus on depency caching based on the Cargo.lock file.